### PR TITLE
fix: add recursion guard to prevent 100% CPU when STDOUT/STDERR is broken

### DIFF
--- a/src/ZM/Logger/ConsoleLogger.php
+++ b/src/ZM/Logger/ConsoleLogger.php
@@ -10,7 +10,7 @@ use Psr\Log\LogLevel;
 
 class ConsoleLogger extends AbstractLogger
 {
-    public const VERSION = '1.1.6';
+    public const VERSION = '1.1.7';
 
     /**
      * 日志输出格式
@@ -85,6 +85,13 @@ class ConsoleLogger extends AbstractLogger
      * @var null|int|resource
      */
     protected $stream;
+
+    /**
+     * 递归保护标志 — 防止日志写入失败时错误处理器再次调用日志导致死循环 CPU 100%
+     *
+     * @var bool
+     */
+    protected static $in_log = false;
 
     /**
      * 是否带颜色
@@ -242,17 +249,27 @@ class ConsoleLogger extends AbstractLogger
         } else {
             $output = $output . PHP_EOL;
         }
-        // use stream
-        if ($this->stream) {
-            fwrite($this->stream, $output);
-            fflush($this->stream);
-        } else {
-            if ($level <= 4 && $this->use_stderr) {
-                fwrite(STDERR, $output);
+        // 递归保护：如果上一次日志写入触发了错误（如终端关闭后 STDOUT/STDERR 破损），
+        // 跳过本次输出，防止错误处理器递归调用导致 CPU 100% 空耗
+        if (self::$in_log) {
+            return;
+        }
+        self::$in_log = true;
+        try {
+            // use stream
+            if ($this->stream) {
+                @fwrite($this->stream, $output);
+                @fflush($this->stream);
             } else {
-                // use plain text output
-                echo $output;
+                if ($level <= 4 && $this->use_stderr) {
+                    @fwrite(STDERR, $output);
+                } else {
+                    // use plain text output
+                    @echo $output;
+                }
             }
+        } finally {
+            self::$in_log = false;
         }
     }
 


### PR DESCRIPTION
## 问题

当从 IDE 终端启动框架后，直接关闭 IDE 而不先停框架时，终端 PTY 被销毁，STDOUT/STDERR 变为破损的文件描述符。此后任何日志调用（`echo`/`fwrite`）都会失败并触发 `E_WARNING`。框架的错误处理器捕获该错误后再次调用 `logger()`，形成递归循环，导致 CPU 100% 空耗。

## 修复

- 添加静态 `$in_log` 递归保护标志
- 在日志输出（`echo`/`fwrite`/`fflush`）外层包裹递归守卫和 `@` 错误抑制
- 版本号从 `1.1.6` 提升到 `1.1.7`

## 关联

本修复是解决 zhamao-framework 在 IDE 终端关闭后 CPU 100% 问题的一部分，需配合 libonebot 信号处理修复一起使用。