### PR TITLE
fix: remove @ error suppression from echo/fwrite/fflush calls

### DIFF
--- a/src/ZM/Logger/ConsoleLogger.php
+++ b/src/ZM/Logger/ConsoleLogger.php
@@ -10,7 +10,7 @@ use Psr\Log\LogLevel;
 
 class ConsoleLogger extends AbstractLogger
 {
-    public const VERSION = '1.1.8';
+    public const VERSION = '1.1.9';
 
     /**
      * 日志输出格式
@@ -258,14 +258,14 @@ class ConsoleLogger extends AbstractLogger
         try {
             // use stream
             if ($this->stream) {
-                @fwrite($this->stream, $output);
-                @fflush($this->stream);
+                fwrite($this->stream, $output);
+                fflush($this->stream);
             } else {
                 if ($level <= 4 && $this->use_stderr) {
-                    @fwrite(STDERR, $output);
+                    fwrite(STDERR, $output);
                 } else {
                     // use plain text output
-                    @echo $output;
+                    echo $output;
                 }
             }
         } finally {


### PR DESCRIPTION
## 问题

`@echo` 是无效的 PHP 语法 — `echo` 是语言结构（language construct），不是函数，`@` 操作符不能应用于它。这会在某些 PHP 版本 / 运行时下导致 parse error（如 CI 中 Windows PHP 8.x 出现的 `syntax error, unexpected token "echo"` 错误）。

## 修复

- 从 `echo`/`fwrite`/`fflush` 调用中移除 `@` 错误抑制符
- 递归保护（`$in_log`）已在 v1.1.7 中添加，足以防止 STDOUT/STDERR 破损时的无限循环
- 版本号从 `1.1.8` 提升到 `1.1.9`

## 关联

- libonebot PR: https://github.com/botuniverse/php-libonebot/pull/114